### PR TITLE
Use named args when calling ngclient Updater()

### DIFF
--- a/tufrepo/repo.py
+++ b/tufrepo/repo.py
@@ -139,10 +139,10 @@ class Repo:
         fsfetcher = FilesystemFetcher({"http://localhost/fakeurl/": "."})
         try:
             updater = Updater(
-                client_dir.name,
-                "http://localhost/fakeurl/",
-                "http://localhost/fakeurl/",
-                fsfetcher,
+                repository_dir=client_dir.name,
+                metadata_base_url="http://localhost/fakeurl/",
+                target_base_url="http://localhost/fakeurl/",
+                fetcher=fsfetcher,
             )
             updater.refresh()
         except RepositoryError as e:


### PR DESCRIPTION
The API is going to change slightly so prepare for that:
better to fail with unknown arg names at that point.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>