### PR TITLE
Separate Keyring interface and implementation

### DIFF
--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -11,7 +11,7 @@ from tuf.api.metadata import DelegatedRole, Delegations, TargetFile
 from tufrepo import helpers
 from tufrepo import verifier
 from tufrepo.git_repo import GitRepository
-from tufrepo.keys import Keyring
+from tufrepo.keys_impl import ComboKeyring
 
 logger = logging.getLogger("tufrepo")
 
@@ -35,7 +35,7 @@ def cli(verbose: int = 0):
 @click.argument("roles", nargs=-1)
 def sign(roles: Tuple[str]):
     """Sign the given roles, using all usable keys in keyring"""
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     for role in roles:
         repo.sign(role)
 
@@ -44,13 +44,13 @@ def sign(roles: Tuple[str]):
 def verify(root_hash: Optional[str] = None):
     """"""
     verifier.verify_repo(root_hash)
-    print(f"Keyring contains keys for [{', '.join(Keyring().keys())}].")
+    print(f"Keyring contains keys for [{', '.join(ComboKeyring().keys())}].")
 
 
 @cli.command()
 def snapshot():
     """"""
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     repo.snapshot()
 
 
@@ -65,7 +65,7 @@ def touch(ctx: click.Context):
     """Mark ROLE as modified to force a new version"""
 
     role = get_role(ctx)
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(role):
         pass
 
@@ -85,7 +85,7 @@ def init(ctx: click.Context, expiry: Tuple[int, str]):
     period = int(delta.total_seconds())
     role = get_role(ctx)
 
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     repo.init_role(role, period)
 
 
@@ -96,7 +96,7 @@ def init(ctx: click.Context, expiry: Tuple[int, str]):
 def set_threshold(ctx: click.Context, delegate: str, threshold: int):
     """Set the threshold of delegated role DELEGATE."""
     role = get_role(ctx)
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(role) as signed:
         helpers.set_threshold(signed, delegate, threshold)
 
@@ -115,7 +115,7 @@ def set_expiry(ctx: click.Context, expiry: Tuple[int, str]):
     period = int(delta.total_seconds())
     role = get_role(ctx)
 
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(role) as signed:
         # This should maybe be a repo feature? argument to edit?
         signed.unrecognized_fields["x-tufrepo-expiry-period"] = period
@@ -129,7 +129,7 @@ def add_key(ctx: click.Context, delegate: str):
 
     The private key secret will be written to privkeys.json."""
     delegator = get_role(ctx)
-    keyring = Keyring()
+    keyring = ComboKeyring()
     key = keyring.generate_key()
     repo = GitRepository(keyring)
 
@@ -145,7 +145,7 @@ def add_key(ctx: click.Context, delegate: str):
 def remove_key(ctx: click.Context, delegate: str, keyid: str):
     """Remove signing key from delegated role DELEGATE"""
     delegator = get_role(ctx)
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(delegator) as signed:
         helpers.remove_key(signed, delegator, delegate, keyid)
 
@@ -156,7 +156,7 @@ def remove_key(ctx: click.Context, delegate: str, keyid: str):
 @click.argument("local-file")
 def add_target(ctx: click.Context, target_path: str, local_file: str):
     """Add a target to a Targets metadata role"""
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(get_role(ctx)) as targets:
         targetfile = TargetFile.from_file(target_path, local_file)
         targets.targets[targetfile.path] = targetfile
@@ -167,7 +167,7 @@ def add_target(ctx: click.Context, target_path: str, local_file: str):
 @click.argument("target-path")
 def remove_target(ctx: click.Context, target_path: str):
     """Remove TARGET from a Targets role ROLE"""
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(get_role(ctx)) as targets:
         del targets.targets[target_path]
 
@@ -186,7 +186,7 @@ def add_delegation(
     hash_prefixes: Tuple[str],
 ):
     """Delegate from ROLE to DELEGATE"""
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     paths = list(paths) if paths else None
     hash_prefixes = list(hash_prefixes) if hash_prefixes else None
 
@@ -204,6 +204,6 @@ def remove_delegation(
     ctx: click.Context,
     delegate: str,
 ):
-    repo = GitRepository(Keyring())
+    repo = GitRepository(ComboKeyring())
     with repo.edit(get_role(ctx)) as targets:
         del targets.delegations.roles[delegate]

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -3,6 +3,7 @@
 
 import click
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import List, Optional, OrderedDict, Tuple
 
@@ -10,19 +11,28 @@ from tuf.api.metadata import DelegatedRole, Delegations, TargetFile
 
 from tufrepo import helpers
 from tufrepo import verifier
+from tufrepo.librepo.keys import Keyring
 from tufrepo.git_repo import GitRepository
-from tufrepo.keys_impl import ComboKeyring
+from tufrepo.keys_impl import EnvVarKeyring, InsecureFileKeyring
 
 logger = logging.getLogger("tufrepo")
 
-def get_role(ctx: click.Context) -> str:
-    """Return parent commands 'role' parameter"""
-    assert ctx.parent
-    return ctx.parent.params["role"]
+@dataclass
+class AppData:
+    keyring: Keyring
+    role: str = None
+
+class Context(click.Context):
+    """click.Context where obj type is Appdata"""
+    def __init__(self):
+        super().__init__()
+        self.obj: AppData
 
 @click.group()
-@click.option("-v", "--verbose", count=True)
-def cli(verbose: int = 0):
+@click.pass_context
+@click.option("-v", "--verbose", count=True, default=0)
+@click.option("--keyring", type=click.Choice(["file", "env"]), default="file")
+def cli(ctx: Context, verbose: int, keyring: str):
     """Edit and sign TUF repository metadata
 
     This tool expects to be run in a (git) metadata repository"""
@@ -30,43 +40,53 @@ def cli(verbose: int = 0):
     logging.basicConfig(format="%(levelname)s:%(message)s")
     logger.setLevel(max(1, 10 * (5 - verbose)))
 
+    if keyring == "env":
+        keyring_obj = EnvVarKeyring()
+    else:
+        keyring_obj = InsecureFileKeyring()
+    ctx.obj = AppData(keyring_obj)
+
 
 @cli.command()
+@click.pass_context
 @click.argument("roles", nargs=-1)
-def sign(roles: Tuple[str]):
+def sign(ctx: Context, roles: Tuple[str]):
     """Sign the given roles, using all usable keys in keyring"""
-    repo = GitRepository(ComboKeyring())
+    repo = GitRepository(ctx.obj.keyring)
     for role in roles:
         repo.sign(role)
 
 @cli.command()
+@click.pass_context
 @click.option("--root-hash")
-def verify(root_hash: Optional[str] = None):
+def verify(ctx: Context, root_hash: Optional[str] = None):
     """"""
     verifier.verify_repo(root_hash)
-    print(f"Keyring contains keys for [{', '.join(ComboKeyring().keys())}].")
+    print(f"Keyring contains keys for [{', '.join(ctx.obj.keyring.keys())}].")
 
 
 @cli.command()
-def snapshot():
+@click.pass_context
+def snapshot(ctx: Context):
     """"""
-    repo = GitRepository(ComboKeyring())
+    repo = GitRepository(ctx.obj.keyring)
     repo.snapshot()
 
 
 @cli.group()
+@click.pass_context
 @click.argument("role")
-def edit(role: str):  # pylint: disable=unused-argument
+def edit(ctx: Context, role: str):
     """Edit metadata for ROLE using the sub-commands."""
+    ctx.obj.role = role
 
 @edit.command()
 @click.pass_context
-def touch(ctx: click.Context):
+def touch(ctx: Context):
     """Mark ROLE as modified to force a new version"""
 
-    role = get_role(ctx)
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(role):
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role):
         pass
 
 @edit.command()
@@ -77,27 +97,25 @@ def touch(ctx: click.Context):
     default=(1, "days"),
     type=(int, click.Choice(["minutes", "days", "weeks"], case_sensitive=False)),
 )
-def init(ctx: click.Context, expiry: Tuple[int, str]):
+def init(ctx: Context, expiry: Tuple[int, str]):
     """Create new metadata for ROLE. Example:
 
     tufrepo edit root init --expiry 52 weeks"""
     delta = timedelta(**{expiry[1]: expiry[0]})
     period = int(delta.total_seconds())
-    role = get_role(ctx)
 
-    repo = GitRepository(ComboKeyring())
-    repo.init_role(role, period)
+    repo = GitRepository(ctx.obj.keyring)
+    repo.init_role(ctx.obj.role, period)
 
 
 @edit.command()
 @click.pass_context
 @click.argument("delegate")
 @click.argument("threshold", type=int)
-def set_threshold(ctx: click.Context, delegate: str, threshold: int):
+def set_threshold(ctx: Context, delegate: str, threshold: int):
     """Set the threshold of delegated role DELEGATE."""
-    role = get_role(ctx)
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(role) as signed:
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role) as signed:
         helpers.set_threshold(signed, delegate, threshold)
 
 
@@ -107,16 +125,15 @@ def set_threshold(ctx: click.Context, delegate: str, threshold: int):
     "expiry",
     type=(int, click.Choice(["minutes", "days", "weeks"], case_sensitive=False)),
 )
-def set_expiry(ctx: click.Context, expiry: Tuple[int, str]):
+def set_expiry(ctx: Context, expiry: Tuple[int, str]):
     """Set expiry period for the role. Example:
 
     tufrepo edit root set-expiry 52 weeks"""
     delta = timedelta(**{expiry[1]: expiry[0]})
     period = int(delta.total_seconds())
-    role = get_role(ctx)
 
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(role) as signed:
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role) as signed:
         # This should maybe be a repo feature? argument to edit?
         signed.unrecognized_fields["x-tufrepo-expiry-period"] = period
 
@@ -124,12 +141,12 @@ def set_expiry(ctx: click.Context, expiry: Tuple[int, str]):
 @edit.command()
 @click.pass_context
 @click.argument("delegate")
-def add_key(ctx: click.Context, delegate: str):
+def add_key(ctx: Context, delegate: str):
     """Add new signing key for delegated role DELEGATE
 
     The private key secret will be written to privkeys.json."""
-    delegator = get_role(ctx)
-    keyring = ComboKeyring()
+    delegator = ctx.obj.role
+    keyring: InsecureFileKeyring = ctx.obj.keyring
     key = keyring.generate_key()
     repo = GitRepository(keyring)
 
@@ -142,10 +159,10 @@ def add_key(ctx: click.Context, delegate: str):
 @click.pass_context
 @click.argument("delegate")
 @click.argument("keyid")
-def remove_key(ctx: click.Context, delegate: str, keyid: str):
+def remove_key(ctx: Context, delegate: str, keyid: str):
     """Remove signing key from delegated role DELEGATE"""
-    delegator = get_role(ctx)
-    repo = GitRepository(ComboKeyring())
+    delegator = ctx.obj.role
+    repo = GitRepository(ctx.obj.keyring)
     with repo.edit(delegator) as signed:
         helpers.remove_key(signed, delegator, delegate, keyid)
 
@@ -154,10 +171,10 @@ def remove_key(ctx: click.Context, delegate: str, keyid: str):
 @click.pass_context
 @click.argument("target-path")
 @click.argument("local-file")
-def add_target(ctx: click.Context, target_path: str, local_file: str):
+def add_target(ctx: Context, target_path: str, local_file: str):
     """Add a target to a Targets metadata role"""
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(get_role(ctx)) as targets:
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role) as targets:
         targetfile = TargetFile.from_file(target_path, local_file)
         targets.targets[targetfile.path] = targetfile
 
@@ -165,10 +182,10 @@ def add_target(ctx: click.Context, target_path: str, local_file: str):
 @edit.command()
 @click.pass_context
 @click.argument("target-path")
-def remove_target(ctx: click.Context, target_path: str):
+def remove_target(ctx: Context, target_path: str):
     """Remove TARGET from a Targets role ROLE"""
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(get_role(ctx)) as targets:
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role) as targets:
         del targets.targets[target_path]
 
 
@@ -179,18 +196,18 @@ def remove_target(ctx: click.Context, target_path: str):
 @click.option("--path", "paths", multiple=True)
 @click.option("--hash-prefix", "hash_prefixes", multiple=True)
 def add_delegation(
-    ctx: click.Context,
+    ctx: Context,
     delegate: str,
     terminating: bool,
     paths: Tuple[str],
     hash_prefixes: Tuple[str],
 ):
     """Delegate from ROLE to DELEGATE"""
-    repo = GitRepository(ComboKeyring())
+    repo = GitRepository(ctx.obj.keyring)
     paths = list(paths) if paths else None
     hash_prefixes = list(hash_prefixes) if hash_prefixes else None
 
-    with repo.edit(get_role(ctx)) as targets:
+    with repo.edit(ctx.obj.role) as targets:
         if targets.delegations is None:
             targets.delegations = Delegations({}, OrderedDict())
 
@@ -201,9 +218,9 @@ def add_delegation(
 @click.pass_context
 @click.argument("delegate")
 def remove_delegation(
-    ctx: click.Context,
+    ctx: Context,
     delegate: str,
 ):
-    repo = GitRepository(ComboKeyring())
-    with repo.edit(get_role(ctx)) as targets:
+    repo = GitRepository(ctx.obj.keyring)
+    with repo.edit(ctx.obj.role) as targets:
         del targets.delegations.roles[delegate]

--- a/tufrepo/git_repo.py
+++ b/tufrepo/git_repo.py
@@ -19,11 +19,20 @@ from tuf.api.serialization.json import JSONSerializer
 
 from tufrepo import helpers
 from tufrepo.librepo.repo import Repository
+from tufrepo.librepo.keys import Keyring
+from tufrepo.keys_impl import ComboKeyring
 
 logger = logging.getLogger("tufrepo")
 
 class GitRepository(Repository):
     """Manages loading, saving (signing) repository metadata in files stored in git"""
+
+    def __init__(self, keyring: ComboKeyring):
+        self._keyring = keyring
+
+    @property
+    def keyring(self) -> Keyring:
+        return self._keyring
 
     @staticmethod
     def _git(command: List[str]):

--- a/tufrepo/git_repo.py
+++ b/tufrepo/git_repo.py
@@ -20,14 +20,13 @@ from tuf.api.serialization.json import JSONSerializer
 from tufrepo import helpers
 from tufrepo.librepo.repo import Repository
 from tufrepo.librepo.keys import Keyring
-from tufrepo.keys_impl import ComboKeyring
 
 logger = logging.getLogger("tufrepo")
 
 class GitRepository(Repository):
     """Manages loading, saving (signing) repository metadata in files stored in git"""
 
-    def __init__(self, keyring: ComboKeyring):
+    def __init__(self, keyring: Keyring):
         self._keyring = keyring
 
     @property

--- a/tufrepo/keys_impl.py
+++ b/tufrepo/keys_impl.py
@@ -20,22 +20,19 @@ from tufrepo.librepo.keys import PrivateKey
 
 logger = logging.getLogger("tufrepo")
 
-class ComboKeyring(Dict[str, Set[PrivateKey]]):
-    """ "Private key management for a repository
+class InsecureFileKeyring(Dict[str, Set[PrivateKey]]):
+    """ "Private key management in plain text
 
-    On Keyring initialization private keys are loaded for all secrets in
-      * env variables (TUF_REPO_PRIVATE_KEY_*) and
-      * privkeys.json file
-    for all delegating roles in this repository.
+    loads secrets from plain text privkeys.json file for all delegating roles
+    in this repository. This currently loads all delegating metadata to find
+    the public keys.
 
-    Private key secrets are only written to disk when store_key() is called.
+    Supports writing secrets to disk with store_key().
     """
 
     def _load_key(self, rolename: str, key: Key):
         # Load a private key from env var or the private key file
-        env_var = f"TUF_REPO_PRIVATE_KEY_{key.keyid}"
-        private = os.getenv(env_var) or self._privkeyfile.get(key.keyid)
-
+        private = self._privkeyfile.get(key.keyid)
         if private:
             if rolename not in self:
                 self[rolename] = set()
@@ -73,7 +70,7 @@ class ComboKeyring(Dict[str, Set[PrivateKey]]):
                     for keyid in role.keyids:
                         self._load_key(role.name, md.signed.delegations.keys[keyid])
 
-        logger.info("Loaded keyring with keys for %d roles", len(self))
+        logger.info("Loaded keys for %d roles from privkeys.json", len(self))
 
     def generate_key(self) -> PrivateKey:
         "Generate a private key"
@@ -105,3 +102,45 @@ class ComboKeyring(Dict[str, Set[PrivateKey]]):
             key.public.keyid[:7],
             role,
         )
+
+class EnvVarKeyring(Dict[str, Set[PrivateKey]]):
+    """ "Private key management using environment variables
+    
+    Load private keys from env variables (TUF_REPO_PRIVATE_KEY_*) for all
+    delegating roles in this repository. This currently loads all delegating
+    metadata to find the public keys.
+    """
+
+    def _load_key(self, rolename: str, key: Key):
+        # Load a private key from env var or the private key file
+        private = os.getenv(f"TUF_REPO_PRIVATE_KEY_{key.keyid}")
+        if private:
+            if rolename not in self:
+                self[rolename] = set()
+            self[rolename].add(PrivateKey(key, private))
+
+    def __init__(self) -> None:
+        # find all delegating roles in the repository
+        roles: Dict[str, int] = {}
+        for filename in glob.glob("*.*.json"):
+            ver_str, delegating_role = filename[: -len(".json")].split(".")
+            if delegating_role not in ["timestamp", "snapshot"]:
+                roles[delegating_role] = max(
+                    int(ver_str), roles.get(delegating_role, 0)
+                )
+
+        # find all signing keys for all roles
+        for delegating_role, version in roles.items():
+            md = Metadata.from_file(f"{version}.{delegating_role}.json")
+            if isinstance(md.signed, Root):
+                for rolename, role in md.signed.roles.items():
+                    for keyid in role.keyids:
+                        self._load_key(rolename, md.signed.keys[keyid])
+            elif isinstance(md.signed, Targets):
+                if md.signed.delegations is None:
+                    continue
+                for role in md.signed.delegations.roles.values():
+                    for keyid in role.keyids:
+                        self._load_key(role.name, md.signed.delegations.keys[keyid])
+
+        logger.info("Loaded keys for %d roles from env vars", len(self))

--- a/tufrepo/keys_impl.py
+++ b/tufrepo/keys_impl.py
@@ -16,27 +16,11 @@ from tuf.api.metadata import (
 )
 from typing import Dict, List, Set
 
+from tufrepo.librepo.keys import PrivateKey
+
 logger = logging.getLogger("tufrepo")
 
-
-class PrivateKey:
-    def __init__(self, key: Key, private: str) -> None:
-        self.public = key
-        self.private = private
-
-        keydict = copy.deepcopy(self.public.to_securesystemslib_key())
-        keydict["keyval"]["private"] = private
-        self.signer = SSlibSigner(keydict)
-
-    def __hash__(self):
-        return hash(self.public.keyid)
-
-    def __eq__(self, other):
-        if isinstance(other, PrivateKey):
-            return self.public.keyid == other.public.keyid
-        return NotImplemented
-
-class Keyring(Dict[str, Set[PrivateKey]]):
+class ComboKeyring(Dict[str, Set[PrivateKey]]):
     """ "Private key management for a repository
 
     On Keyring initialization private keys are loaded for all secrets in

--- a/tufrepo/librepo/keys.py
+++ b/tufrepo/librepo/keys.py
@@ -1,0 +1,23 @@
+import copy
+from typing import Mapping
+from securesystemslib.signer import SSlibSigner
+from tuf.api.metadata import Key
+
+class PrivateKey:
+    def __init__(self, key: Key, private: str) -> None:
+        self.public = key
+        self.private = private
+
+        keydict = copy.deepcopy(self.public.to_securesystemslib_key())
+        keydict["keyval"]["private"] = private
+        self.signer = SSlibSigner(keydict)
+
+    def __hash__(self):
+        return hash(self.public.keyid)
+
+    def __eq__(self, other):
+        if isinstance(other, PrivateKey):
+            return self.public.keyid == other.public.keyid
+        return NotImplemented
+
+Keyring = Mapping[str, set[PrivateKey]]

--- a/tufrepo/librepo/repo.py
+++ b/tufrepo/librepo/repo.py
@@ -12,13 +12,11 @@ from typing import Dict, Generator
 
 from tuf.api.metadata import Metadata, MetaFile, Signed
 
-from tufrepo.keys import Keyring
+from tufrepo.librepo.keys import Keyring
 
 logger = logging.getLogger("tufrepo")
 
 class Repository(ABC):
-    def __init__(self, keyring: Keyring) -> None:
-        self.keyring = keyring
 
     def _sign_role(self, role: str, metadata: Metadata, clear_sigs: bool):
         if clear_sigs:
@@ -31,6 +29,12 @@ class Repository(ABC):
                 metadata.sign(key.signer, append=True)
         except KeyError:
             logger.info(f"No keys for role %s found in keyring", role)
+
+    @property
+    @abstractmethod
+    def keyring(self) -> Keyring:
+        """return a Keyring containing the private keys needed for signing"""
+        raise NotImplementedError
 
     @abstractmethod
     def _load(self, role:str) -> Metadata:


### PR DESCRIPTION
This makes it clearer what the Repository interface actually needs:
just a Mapping of role names to some private key representation
(maybe that representation could even be a plain Signer, but right 
now it's a bit more).

Also separate the two Keyring implementations: they are never needed at the same time.
