### PR TITLE
Add support for succinct hash bin delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ This key management solution is preliminary and likely to change in the future.
 
     tufrepo --help
 
+If you want to debug a specific command locally you can have a look at
+`click` documentation about it: https://click.palletsprojects.com/en/8.1.x/testing/.
+It may be  worth setting a temporary folder where you can test your command in
+order to simulate tufrepo behavior.
+
 ## Examples
 
 Note: The tool outputs very little currently: Running `git diff` once in a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 securesystemslib[pynacl]
-tuf==1.1.0
+# Build from source the latest changes in the develop branch of python-tuf.
+git+https://github.com/theupdateframework/python-tuf.git@develop
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 securesystemslib[pynacl]
-# Build from source the latest changes in the develop branch of python-tuf.
-git+https://github.com/theupdateframework/python-tuf.git@develop
+# Install from git to get succinct delegations support (should be in 2.0 release)
+git+https://github.com/theupdateframework/python-tuf.git@3516cc36b607898bdbd94bcc0a4d9abcd4b67722
 click

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,9 @@ class TestCLI(unittest.TestCase):
         if expected_out is not None:
            self.assertEqual(proc.stdout, expected_out)
         if expected_err is not None:
-           self.assertEqual(proc.stderr, expected_err)
+            if proc.stderr != expected_err:
+                print(proc.stderr)
+            self.assertEqual(proc.stderr, expected_err)
         self.assertEqual(proc.returncode, 0)
 
         return proc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,5 +205,141 @@ class TestCLI(unittest.TestCase):
         files |= { "5.snapshot.json", "3.targets.json" }
         self.assertEqual(set(os.listdir(self.cwd)), files)
 
+    def test_targets_changes(self):
+        """Test multiple changes in targets delegations"""
+        subprocess.run(["git", "init", "."], cwd=self.cwd, capture_output=True)
+        subprocess.run(["git", "config", "--local", "user.name", "test"], cwd=self.cwd)
+        subprocess.run(["git", "config", "--local", "user.email", "test@example.com"], cwd=self.cwd)
+
+        # Create initial metadata
+        self._run("init")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "Initial metadata"], cwd=self.cwd, capture_output=True)
+
+        self.assertIn("Metadata with 0 delegated targets verified", proc.stdout)
+        self.assertIn("Keyring contains keys for [root, snapshot, targets, timestamp]", proc.stdout)
+        files = {".git", "1.root.json", "1.snapshot.json", "1.targets.json", "privkeys.json", "timestamp.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Add new role, delegate to role
+        self._run("edit targets add-delegation --path 'files/*' role1")
+        self._run("edit targets add-key role1")
+        self._run("edit role1 init")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "Add role, delegate"], cwd=self.cwd, capture_output=True)
+
+        # 1.targets.json is used for verification until a snapshot update.
+        self.assertStartsWith(proc.stdout, "Metadata with 0 delegated targets verified")
+        files |= { "2.targets.json", "1.role1.json" }
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Update snapshot
+        self._run("snapshot")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "snapshot"], cwd=self.cwd, capture_output=True)
+
+        self.assertStartsWith(proc.stdout, "Metadata with 1 delegated targets verified")
+        files -= { "1.snapshot.json", "1.targets.json" }
+        files.add("2.snapshot.json")
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Add another role with multiple hash prefixes
+        self._run("edit targets add-delegation --hash-prefix 00 --hash-prefix 01 role2")
+        self._run("edit targets add-key role2")
+        self._run("edit role2 init")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "Add second role, delegate"], cwd=self.cwd, capture_output=True)
+
+        # 2.targets.json is used for verification until a snapshot update.
+        self.assertStartsWith(proc.stdout, "Metadata with 1 delegated targets verified")
+        files |= {"3.targets.json", "1.role2.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Update snapshot
+        self._run("snapshot")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "snapshot"], cwd=self.cwd, capture_output=True)
+
+        self.assertStartsWith(proc.stdout, "Metadata with 2 delegated targets verified")
+        files -= {"2.snapshot.json", "2.targets.json"}
+        files.add("3.snapshot.json")
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Add succinct hash delegation removing all other delegated role info.
+        self._run("edit targets add-delegation --succinct 4 bin")
+        proc = self._run("verify", expected_out=None)
+
+        # 3.targets.json is used for verification until a snapshot update.
+        # Also, no delegated bin files were yet initialized.
+        self.assertStartsWith(proc.stdout, "Metadata with 2 delegated targets verified")
+        files.add("4.targets.json")
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Initialize delegated bin files based on the info in targets.
+        self._run("init-succinct-roles targets")
+
+        # Update snapshot to use the 4.targets.json with the succint roles info.
+        self._run("snapshot")
+        proc = self._run("verify", expected_out=None)
+        subprocess.run(["git", "commit", "-a", "-m", "snapshot"], cwd=self.cwd, capture_output=True)
+
+        # Only the delegated bins are considered as delegated targets.
+        self.assertStartsWith(proc.stdout, "Metadata with 4 delegated targets verified")
+        files -= {"3.snapshot.json", "3.targets.json"}
+        files |= {"4.snapshot.json", "1.bin-0.json", "1.bin-1.json", "1.bin-2.json", "1.bin-3.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Delegate to a new role in targets removing the succinct hash info.
+        self._run("edit targets add-delegation --path 'files/*' role1")
+        self._run("edit targets add-key role1")
+        self._run("edit role1 init")
+        # Update snapshot to use the 5.targets.json without the succint info.
+        self._run("snapshot")
+
+        files -= {"4.snapshot.json", "4.targets.json"}
+        files |= {"5.snapshot.json", "5.targets.json", "1.role1.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        # Remove all bins as "targets" doesn't delegate to them anymore.
+        subprocess.run(
+            ["rm",  "1.bin-0.json", "1.bin-1.json", "1.bin-2.json", "1.bin-3.json"],
+            cwd=self.cwd,
+            capture_output=True
+        )
+
+        proc = self._run("verify", expected_out=None)
+        subprocess.run([
+            "git",
+            "commit", "-a", "-m", "Add role, delegate and remove succinct info"],
+            cwd=self.cwd,
+            capture_output=True,
+        )
+
+        self.assertStartsWith(proc.stdout, "Metadata with 1 delegated targets verified")
+        files -= {"1.bin-0.json", "1.bin-1.json", "1.bin-2.json", "1.bin-3.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
+        #### Cases that throw exception ####
+        # Adding standard delegation and succinct hash bin delegation at once.
+        self._run(
+            "edit targets add-delegation --path a/b --succinct 32 bin",
+            "",
+            expected_err= "Not allowed to set delegated role options and the succinct option"
+        )
+
+        # Adding succinct hash delegation with zero bin amount.
+        self._run(
+            "edit targets add-delegation --succinct 0 bin",
+            "",
+            "Succinct number must be at least 2"
+        )
+
+        # Adding succinct delegation with bin amount that is not a power of 2.
+        self._run(
+            "edit targets add-delegation --succinct 3 bin",
+            "",
+            "Succinct number must be a power of 2"
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ class TestCLI(unittest.TestCase):
                 f"Expected '{needle}...', got '{haystack[:len(needle)]}...'"
             )
 
-    def _run(self, args: str, expected_out:Optional[str]="", expected_err:Optional[str]="") -> subprocess.CompletedProcess:
+    def _run(self, args: str, expected_out:Optional[str]="", expected_err:Optional[str]=None) -> subprocess.CompletedProcess:
         proc = subprocess.run(
             args=["tufrepo"] + args.split(),
             capture_output=True, 
@@ -40,10 +40,12 @@ class TestCLI(unittest.TestCase):
         if expected_out is not None:
            self.assertEqual(proc.stdout, expected_out)
         if expected_err is not None:
-            if proc.stderr != expected_err:
+            if expected_err not in proc.stderr:
                 print(proc.stderr)
-            self.assertEqual(proc.stderr, expected_err)
-        self.assertEqual(proc.returncode, 0)
+            self.assertIn(expected_err, proc.stderr)
+            self.assertEqual(proc.returncode, 1)
+        else:
+            self.assertEqual(proc.returncode, 0)
 
         return proc
  

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -111,7 +111,7 @@ def verify(ctx: Context, root_hash: Optional[str] = None):
 @cli.command()
 @click.pass_context
 def snapshot(ctx: Context):
-    """"""
+    """Update snapshot and timestamp meta information"""
     ctx.obj.repo.snapshot()
 
 

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -77,7 +77,7 @@ def init(ctx: Context):
     with ctx.obj.repo.edit("root") as root:
         for role in ["root", "timestamp", "snapshot", "targets"]:
             key = ctx.obj.keyring.generate_key()
-            root.add_key(role, key.public)
+            root.add_key(key.public, role)
             ctx.obj.keyring.store_key(role, key)
 
     ctx.obj.repo.init_role("timestamp", period)

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -262,6 +262,7 @@ def remove_delegation(
     ctx: Context,
     delegate: str,
 ):
+    """Remove DELEGATE from ROLE"""
     tar: Targets
     with ctx.obj.repo.edit(ctx.obj.role) as tar:
         if tar.delegations is not None and tar.delegations.roles is not None:

--- a/tufrepo/helpers.py
+++ b/tufrepo/helpers.py
@@ -27,7 +27,7 @@ def set_threshold(self: Signed, delegate: str, threshold: int):
 def add_key(self: Signed, delegator: str, delegate: str, key: Key):
     if isinstance(self, Root) or isinstance(self, Targets):
         try:
-            self.add_key(delegate, key)
+            self.add_key(key, delegate)
         except ValueError:
             raise ClickException(f"{delegator} does not delegate to {delegate}")
     else:
@@ -37,7 +37,7 @@ def add_key(self: Signed, delegator: str, delegate: str, key: Key):
 def remove_key(self: Signed, delegator: str, delegate: str, keyid: str):
     if isinstance(self, Root) or isinstance(self, Targets):
         try:
-            self.remove_key(delegate, keyid)
+            self.revoke_key(keyid, delegate)
         except ValueError:
             raise ClickException(f"{delegator} does not delegate to {delegate}")
     else:

--- a/tufrepo/helpers.py
+++ b/tufrepo/helpers.py
@@ -14,7 +14,7 @@ def set_threshold(self: Signed, delegate: str, threshold: int):
     if isinstance(self, Root):
         role = self.roles.get(delegate)
     elif isinstance(self, Targets):
-        if self.delegations is not None:
+        if self.delegations is not None and self.delegations.roles is not None:
             role = self.delegations.roles.get(delegate)
     else:
         raise ClickException(f"Not a delegator")

--- a/tufrepo/keys_impl.py
+++ b/tufrepo/keys_impl.py
@@ -57,11 +57,17 @@ class Keyring(DefaultDict[str, Set[PrivateKey]], metaclass=abc.ABCMeta):
             elif isinstance(md.signed, Targets):
                 if md.signed.delegations is None:
                     continue
-                for role in md.signed.delegations.roles.values():
-                    for keyid in role.keyids:
-                        self._load_key(
-                            role.name, md.signed.delegations.keys[keyid]
-                        )
+                if md.signed.delegations.roles is not None:
+                    for role in md.signed.delegations.roles.values():
+                        for keyid in role.keyids:
+                            self._load_key(
+                                role.name, md.signed.delegations.keys[keyid]
+                            )
+                elif md.signed.delegations.succinct_roles is not None:
+                    for bin in md.signed.delegations.succinct_roles.get_roles():
+                        for keyid in  md.signed.delegations.keys.keys():
+                            self._load_key(bin, md.signed.delegations.keys[keyid])
+
 
 class InsecureFileKeyring(Keyring):
     """Private key management in plain text file


### PR DESCRIPTION
**Note this pr is dependant on #33**

With this pr I add support for succinct hash bin delegation.

The pr introduces two commands:
1. `tufrepo edit X add-delegation --succinct <options>`  edits targets role X, making the delegation into a succinct one
2. `tufrepo init-succinct-roles X` reads the delegation and initializes all the delegated metadata files

There are additional commits that are aiming to simplify or improve the codebase. 