### PR TITLE
No-op snapshot

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,12 @@ class TestCLI(unittest.TestCase):
         files.add("2.snapshot.json")
         self.assertEqual(set(os.listdir(self.cwd)), files)
 
+        # Update snapshot when it's not needed (expect nothing to happen)
+        self._run("snapshot")
+        proc = subprocess.run(["git", "diff", "--quiet"], cwd=self.cwd)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(set(os.listdir(self.cwd)), files)
+
         # Add target to role1 (don't add file to git)
         self._run("edit role1 add-target --no-target-in-repo files/timestamp.json timestamp.json")
 

--- a/tufrepo/verifier.py
+++ b/tufrepo/verifier.py
@@ -43,7 +43,7 @@ def verify_repo(root_hash: Optional[str]):
         updater.refresh()
     except RepositoryError as e:
         # TODO: improve this message by checking for common mistakes?
-        raise ClickException("Top-level metadata fails to validate") from e
+        raise ClickException(f"Top-level metadata fails to validate: {e}") from e
 
     # recursively verify all targets in delegation tree
     # This code is pretty horrible
@@ -87,7 +87,7 @@ def verify_repo(root_hash: Optional[str]):
                     )
                 except RepositoryError as e:
                     raise ClickException(
-                        f"Delegated target {role.name} fails to validate"
+                        f"Delegated target {role.name} fails to validate: {e}"
                     ) from e
     deleg_count = len(updater._trusted_set) - 4
 


### PR DESCRIPTION
Handle snapshot command when a new snapshot is not needed

If snapshot is not needed when user calls it (no targets versions were added or updated), avoid bumping snapshot version and expiry. This is useful in tuf-demo because the snapshot process can then run after every push and won't need complex logic to figure out when it needs to run.

This should then allow the snapshot task in tuf-demo workflow to look something like:

          tufrepo snapshot 
          tufrepo verify --root-hash 24d9b03f10ce0fe2e648833de26af60a4a8cd4e65bb396a8200a3194ae8ea76e
          # only set value to true if we really created a new snapshot, not if new snapshot was not needed
          git diff --quiet || echo "::set-output name=snapshot::true"

Fixes #37