### PR TITLE
Re-design target addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ while helps keep track of changes so far.
 
 ### Succinct delegation
 
-    # Add delegation to 16 roles named "bin-0" to "bin-f" to targets (sign with targets key)
-    # Also create a key for those roles
-    tufrepo edit targets add-delegation --succinct 16 bin
+    # Add delegation to 16 roles named "bin-0" to "bin-f" to role1 (sign with role1 key)
+    # Also create a key for those succinct roles
+    tufrepo edit role1 add-delegation --succinct 16 bin
     
     # Create the 16 roles, sign with the key created earlier
-    tufrepo init-succinct-roles targets
+    tufrepo init-succinct-roles role1
 
     # Update snapshot/timestamp contents (sign with snapshot/timestamp keys)
     tufrepo snapshot
@@ -148,8 +148,9 @@ while helps keep track of changes so far.
 
 ### Adding target files
 
-    # Developer adds target "files/file1.txt" (sign with role1 key)
-    tufrepo edit role1 add-target files/file1.txt ../targets/files/file1.txt
+    # Developer adds target "files/file1.txt": this is delegated first to "role1",
+    # then to "bin-2", so change is signed by the succinct role key
+    tufrepo add-target files/file1.txt ../targets/files/file1.txt
 
     # Update snapshot/timestamp contents (sign with snapshot/timestamp key)
     tufrepo snapshot

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,16 +306,24 @@ class TestCLI(unittest.TestCase):
             "add-target --no-target-in-repo target/path timestamp.json",
             "Added 'target/path' as target to role 'bin-1'\n"
         )
+        self._run("snapshot")
+        subprocess.run(["git", "commit", "-a", "-m", "add target to delegated bin"], cwd=self.cwd, capture_output=True)
+
+        # expect that target was added to bin-1 because of delegation
+        files -= {"4.snapshot.json", "1.bin-1.json"}
+        files |= {"5.snapshot.json", "2.bin-1.json"}
+        self.assertEqual(set(os.listdir(self.cwd)), files)
 
         # Delegate to a new role in targets removing the succinct hash info.
         self._run("edit targets add-delegation --path 'files/*' role1")
         self._run("edit targets add-key role1")
         self._run("edit role1 init")
-        # Update snapshot to use the 5.targets.json without the succint info.
+
+        # Update snapshot to use new targets metadata without the succint info.
         self._run("snapshot")
 
-        files -= {"4.snapshot.json", "4.targets.json", "1.bin-1.json"}
-        files |= {"5.snapshot.json", "5.targets.json", "1.role1.json", "2.bin-1.json"}
+        files -= {"5.snapshot.json", "4.targets.json"}
+        files |= {"6.snapshot.json", "5.targets.json", "1.role1.json"}
         self.assertEqual(set(os.listdir(self.cwd)), files)
 
         # Remove all bins as "targets" doesn't delegate to them anymore.

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -149,6 +149,30 @@ def init_succinct_roles(ctx: Context, role: str):
             ctx.obj.repo.init_role(bin_name, period)
 
 
+
+@cli.command()
+@click.pass_context
+@click.option("--target-in-repo/--no-target-in-repo", default=True)
+@click.option("--follow-delegations/--no-follow-delegations", default=True)
+@click.option("--role", default="targets")
+@click.argument("target-path")
+@click.argument("local-file")
+def add_target(
+    ctx: Context,
+    target_in_repo: bool,
+    follow_delegations: bool,
+    role: str,
+    target_path: str,
+    local_file: str,
+):
+    """Add a target file to the repository"""
+    final_role = ctx.obj.repo.add_target(
+        role, follow_delegations, target_in_repo, target_path, local_file
+    )
+    print(f"Added '{target_path}' as target to role '{final_role}'")
+
+
+
 # ------------------------------- edit commands --------------------------------
 
 
@@ -238,22 +262,6 @@ def remove_key(ctx: Context, delegate: str, keyid: str):
     with ctx.obj.repo.edit(delegator) as signed:
         helpers.remove_key(signed, delegator, delegate, keyid)
 
-
-@edit.command()
-@click.pass_context
-@click.option("--target-in-repo/--no-target-in-repo", default=True)
-@click.argument("target-path")
-@click.argument("local-file")
-def add_target(
-    ctx: Context,
-    target_in_repo: bool,
-    target_path: str,
-    local_file: str,
-):
-    """Add a target to a Targets metadata role"""
-    ctx.obj.repo.add_target(
-        ctx.obj.role, target_in_repo, target_path, local_file
-    )
 
 
 @edit.command()


### PR DESCRIPTION
Fixes #32

---

Adding a target only modifies a single metadata so making it a "edit" sub
command made sense... However, often user does not know which metadata
should be modified: this is especially the case with succinct
delegations.

Make add-target a top level action instead of a edit subaction:
* role can still be optionally specified but it is a starting point for the search
* delegation tree is followed from the starting role until the first leaf role (that does not delegate further) is found
* command now also outputs which role it inserted the target file into

This means add-target is now a simple repository wide command which
seems quite logical: user does not need to know the details, they just
want to add a target file to the repository.

There is a edit()-refactor here that makes the edit-contextmanager handle `AbortEdit` silently: the users of edit() can raise `AbortEdit` to signal they want to exit the contextmanager without saving the edited metadata. This is a bit undiscoverable and not immediately obvious but works quite nicely in both `snapshot` and `add-target` in my opinion.