### PR TITLE
Remove target with delegations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,33 +30,49 @@ experimental and unstable:
 
 The tufrepo tool works in a git-stored TUF metadata directory: metadata files
 are automatically added to git. Git is used for a few reasons:
- * This means the tool needs no state tracking as git knows whether a file
-   has been modified already
- * Reviewing changes, committing them as logical chunks and reverting wrong
+ * Tool needs no state tracking as git knows if file has been modified
+ * Reviewing changes, combining changes to logical chunks and reverting wrong
    changes becomes easy
  * publishing and sharing repositories (and even running tufrepo on CI)
    is possible
 
 ### Commands are used to edit metadata
 
-'init' command initializes a new repository: the same results can be achieved
-with individually editing each top level role, 'init' is just a short cut.
-
-The 'edit' command modifies a single metadata file (there are many
-sub-commands, see examples). The 'snapshot' command updates the repository
-snapshot and timestamp. During 'edit' and 'snapshot' commands the tool takes
-care of:
+While editing, the tool takes care of:
  * expiry updates
- * metadata version numbers
- * file name changes
- * signing (with all private keys available)
+ * version number updates
+ * file name changes, deleting obsolete files
+ * signing (with all appropriate private keys that available)
 
-The 'sign' command signs metadata without otherwise modifying it.
-Signing happens automatically during 'edit' and 'snapshot' but sometimes
-all keys are not available at edit time -- in these cases signing without
-modifying the signed content is useful.
+Following commands are available to user:
 
-The 'verify' command verifies repository validity.
+| Command               | Description
+| ---                   | ---
+| `init`                | Initialize a minimal repository from scratch
+| `add-target`          | Add target file to the repository
+| `remove-target`       | Remove target file from the repository
+| `snapshot`            | Update snapshot and timestamp meta information
+| `sign`                | Sign roles (without otherwise modifying them)
+| `init-succinct-roles` | Initialize delegated roles for a succinct delegation
+| `verify`              | Verify the current status of the repository
+| `edit`                | Edit a role with subcommands listed below
+
+A specific role can be edited with following edit-subcommands:
+
+| Edit sub-command    | Description
+| ---                 | ---
+| `init`              | Create new metadata for role
+| `add-delegation`    | Delegate from role to another role
+| `remove-delegation` | Remove delegation to another role
+| `add-key`           | Add new signing key for a delegated role
+| `remove-key`        | Remove signing key for a delegated role
+| `set-threshold`     | Set the threshold of delegated role
+| `set-expiry`        | Set expiry period for the role
+| `touch`             | No changes, just update version and expiry
+
+When editing, the results can be checked with `git diff` and then committed
+with `git commit -a`. Note that git status affects the automatic version number
+changes: version number is bumped once per git changeset.
 
 ### Key management
 

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -185,6 +185,30 @@ def add_target(
     print(f"Added '{target_path}' as target to role '{final_role}'")
 
 
+@cli.command
+@click.pass_context
+@click.option("--no-follow-delegations", is_flag=True, default=False)
+@click.option("--role", default="targets", metavar="ROLE", show_default=True)
+@click.argument("target-path")
+def remove_target(
+    ctx: Context,
+    no_follow_delegations: bool,
+    role: str,
+    target_path: str,
+    ):
+    """Remove target file from the repository"""
+
+    final_role = ctx.obj.repo.remove_target(
+        role, not no_follow_delegations, target_path
+    )
+
+    if not final_role:
+        print(f"Target {target_path} not found")
+    else:
+        print(f"Removed {target_path} from role {final_role}.")
+        print("Actual target files have not been removed")
+
+
 
 # ------------------------------- edit commands --------------------------------
 
@@ -275,19 +299,6 @@ def remove_key(ctx: Context, delegate: str, keyid: str):
     with ctx.obj.repo.edit(delegator) as signed:
         helpers.remove_key(signed, delegator, delegate, keyid)
 
-
-
-@edit.command()
-@click.pass_context
-@click.argument("target-path")
-def remove_target(ctx: Context, target_path: str):
-    """Remove TARGET from a Targets role ROLE"""
-
-    targets: Targets
-    with ctx.obj.repo.edit(ctx.obj.role) as targets:
-        del targets.targets[target_path]
-    print(f"Removed {target_path} from {ctx.obj.role}.")
-    print("Actual target files have not been removed")
 
 
 @edit.command()

--- a/tufrepo/cli.py
+++ b/tufrepo/cli.py
@@ -112,9 +112,15 @@ def verify(ctx: Context, root_hash: Optional[str] = None):
 @cli.command()
 @click.pass_context
 def snapshot(ctx: Context):
-    """Update snapshot and timestamp meta information"""
-    ctx.obj.repo.snapshot()
+    """Update both snapshot and timestamp meta information if needed"""
+    if ctx.obj.repo.snapshot():
+        ctx.obj.repo.timestamp()
 
+@cli.command()
+@click.pass_context
+def timestamp(ctx: Context):
+    """Update timestamp meta information"""
+    ctx.obj.repo.timestamp()
 
 @cli.command()
 @click.pass_context

--- a/tufrepo/git_repo.py
+++ b/tufrepo/git_repo.py
@@ -152,11 +152,11 @@ class GitRepository(Repository):
             version, _ = filename[: -len(".json")].split(".")
             current_version = max(current_version, int(version))
 
-        old_snapshot_version = super().timestamp(current_version)
+        old_snapshot_meta = super().timestamp(MetaFile(current_version))
 
-        if old_snapshot_version:
+        if old_snapshot_meta:
             with suppress(FileNotFoundError):
-                os.remove(f"{old_snapshot_version}.snapshot.json")
+                os.remove(f"{old_snapshot_meta.version}.snapshot.json")
 
     @contextmanager
     def edit(self, role: str) -> Generator[Signed, None, None]:

--- a/tufrepo/git_repo.py
+++ b/tufrepo/git_repo.py
@@ -177,10 +177,12 @@ class GitRepository(Repository):
         if os.path.exists(old_filename) and self._git(diff_cmd) == 0:
             version += 1
 
-        # allow user to cancel the edit by raising AbortEdit
+        # Yield for editing but allow user to cancel by raising AbortEdit
         with suppress(AbortEdit):
-            with super()._edit(role, expiry, version) as signed:
-                yield signed
+            yield md.signed
+            md.signed.expires = expiry
+            md.signed.version = version
+            self._save(role, md)
 
     def add_target(
         self,

--- a/tufrepo/librepo/repo.py
+++ b/tufrepo/librepo/repo.py
@@ -8,7 +8,7 @@ import logging
 from abc import abstractmethod, ABC
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Dict, Generator, Optional, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 
 from tuf.api.metadata import Metadata, MetaFile, Signed, TargetFile, Targets, Timestamp
 
@@ -128,8 +128,7 @@ class Repository(ABC):
             return None
         return old_snapshot_version
 
-
-    def add_target(self, role, follow_delegations: bool, targetfile: TargetFile) -> str:
+    def add_target(self, role:str, follow_delegations: bool, targetfile: TargetFile) -> str:
         """Adds a file to the repository as a target
 
         role: name of targets role that is the starting point for the targets-role search
@@ -180,7 +179,7 @@ class Repository(ABC):
 
                 # target file was not found in this metadata: try delegations
                 if targets.delegations and follow_delegations:
-                    child_roles = []
+                    child_roles: List[str] = []
                     for (
                         child, terminating
                     ) in targets.delegations.get_roles_for_target(target_path):

--- a/tufrepo/librepo/repo.py
+++ b/tufrepo/librepo/repo.py
@@ -69,17 +69,6 @@ class Repository(ABC):
         md = self._load(role)
         self._save(role, md, False)
 
-    @contextmanager
-    def _edit(self, role:str, expiry: datetime, version: int) -> Generator[Signed, None, None]:
-        """Helper function for edit() implementations"""
-        md = self._load(role)
-
-        yield md.signed
-
-        md.signed.expires = expiry
-        md.signed.version = version
-        self._save(role, md)
-
     def snapshot(self, current_targets: Dict[str, MetaFile]) -> Tuple[bool, Dict[str, MetaFile]]:
         """Update snapshot and timestamp meta information
 

--- a/tufrepo/librepo/repo.py
+++ b/tufrepo/librepo/repo.py
@@ -111,22 +111,22 @@ class Repository(ABC):
 
         return updated_snapshot, removed
 
-    def timestamp(self, snapshot_version: int) -> Optional[int]:
+    def timestamp(self, snapshot_meta: MetaFile) -> Optional[MetaFile]:
         """Update timestamp meta information
 
-        Updates timestamp with given snapshot version number.
+        Updates timestamp with given snapshot information.
 
-        Returns the snapshot version that was removed from repository (if any).
+        Returns the snapshot that was removed from repository (if any).
         """
         with self.edit("timestamp") as timestamp:
             timestamp: Timestamp
-            old_snapshot_version = timestamp.snapshot_meta.version
-            timestamp.snapshot_meta = MetaFile(snapshot_version)
+            old_snapshot_meta = timestamp.snapshot_meta
+            timestamp.snapshot_meta = snapshot_meta
 
         logger.info("Timestamp updated")
-        if old_snapshot_version == snapshot_version:
+        if old_snapshot_meta.version == snapshot_meta.version:
             return None
-        return old_snapshot_version
+        return old_snapshot_meta
 
     def add_target(self, role:str, follow_delegations: bool, targetfile: TargetFile) -> str:
         """Adds a file to the repository as a target


### PR DESCRIPTION
This started with just refactoring the remove-target (so it matches add-target) but turned into a collection of multiple changes:
* make `remove-target` like `add-target` (it is a top level command and follows delegations too)
* refactor both `remove-target` and `add-target` so that the generic parts are in Repository and only git-related parts are in GitRepository
* make `timestamp` a top-level command as well
* separate timestamp functionality out of `*Repository.snapshot()` into it's own method (making sure the obsolete snapshot files are always deleted when they become obsolete)
* remove workaround in `edit()` where some files would be deleted there: now only `GitRepository.timestamp()` and `GitRepository.snapshot()` delete files (because only they make files obsolete)
* Improve README

Should be noted that while timestamp and snapshot are now separated in the Repository class, the CLI `snapshot` command still does a timestamp if needed.

Fixes #46, fixes #47, fixes #31