### PR TITLE
Edit refactor

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,15 +325,15 @@ class TestCLI(unittest.TestCase):
         files |= {"6.snapshot.json", "3.bin-1.json"}
 
         # Delegate to a new role in targets removing the succinct hash info.
-        self._run("edit targets add-delegation --path 'files/*' role1")
-        self._run("edit targets add-key role1")
-        self._run("edit role1 init")
+        self._run("edit targets add-delegation --path 'files/*' role3")
+        self._run("edit targets add-key role3")
+        self._run("edit role3 init")
 
         # Update snapshot to use new targets metadata without the succint info.
         self._run("snapshot")
 
         files -= {"6.snapshot.json", "4.targets.json"}
-        files |= {"7.snapshot.json", "5.targets.json", "1.role1.json"}
+        files |= {"7.snapshot.json", "5.targets.json", "1.role3.json"}
         self.assertEqual(set(os.listdir(self.cwd)), files)
 
         # Remove all bins as "targets" doesn't delegate to them anymore.

--- a/tufrepo/helpers.py
+++ b/tufrepo/helpers.py
@@ -4,9 +4,8 @@
 """Some helpers for editing Metadata"""
 
 from click.exceptions import ClickException
-from datetime import datetime
 
-from tuf.api.metadata import Key, Metadata, Root, Signed, Targets
+from tuf.api.metadata import Key, Root, Signed, Targets
 
 
 def set_threshold(self: Signed, delegate: str, threshold: int):


### PR DESCRIPTION
Refactor Repository.edit()

Hide the contextmanager complexity from the concrete Repository implementation. Do this by introducing a new class MetadataDescriptor.
    
Implementations now only need to implement:
* `Repository.open()`: open a metadata for editing, return a MetadataDescriptor
* `MetadataDescriptor.close()`: store the metadata, possibly updating expiry, version and signatures
* `MetadataDescriptor.signed`: property to access the metadata content for modifications

This change does not affect the users of Repository.edit(): it functions just like before.

Majority of the code changes are moving methods from GitRepository to GitMetadata.
