### PR TITLE
Bump python-tuf to 2.0.0 and start using TAP 15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 securesystemslib[pynacl]
-# Install from git to get succinct delegations support (should be in 2.0 release)
-git+https://github.com/theupdateframework/python-tuf.git@3516cc36b607898bdbd94bcc0a4d9abcd4b67722
+tuf==2.0.0
 click

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         'Click',
         'securesystemslib[pynacl]',
-        'tuf @ git+https://github.com/theupdateframework/python-tuf.git@3516cc36b607898bdbd94bcc0a4d9abcd4b67722',
+        'tuf>=2.0.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Bump python-tuf to 2.0.0 and start using succinct hash bin delegation
or TAP 15.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>